### PR TITLE
Starting with AppCompat v1.1.0-alpha05, setDefaultNightMode() does no…

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
 
     implementation 'com.google.android.material:material:1.1.0-alpha05'
-    implementation 'androidx.appcompat:appcompat:1.1.0-alpha04'
+    implementation 'androidx.appcompat:appcompat:1.1.0-alpha05'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
     implementation 'androidx.preference:preference:1.1.0-alpha04'
 


### PR DESCRIPTION
Starting with AppCompat v1.1.0-alpha05, setDefaultNightMode() does not automatically recreate any started activities.

https://developer.android.com/preview/features/darktheme